### PR TITLE
Rename to new umbrella name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# Titles
+# WritingStyle
 
-A set of ready-made titling helper methods for use in your Laravel application.
+A set of ready-made writing style helper methods (titling, date formatting, etc.) for use in your Laravel application.
 
-[![Latest Stable Version](http://poser.pugx.org/hotmeteor/titles/v)](https://packagist.org/packages/hotmeteor/titles)
+[![Latest Stable Version](http://poser.pugx.org/hotmeteor/writing-style/v)](https://packagist.org/packages/hotmeteor/writing-style)
 
 ## Installation
 
 ```shell
-composer require hotmeteor/titles
+composer require hotmeteor/writing-style
 ```
 
 ## Usage

--- a/composer.json
+++ b/composer.json
@@ -1,11 +1,12 @@
 {
-  "name": "hotmeteor/titles",
-  "description": "A set of ready-made title helper methods for use in your Laravel application.",
+  "name": "hotmeteor/writing-style",
+  "description": "A set of ready-made writing style helper methods (titling, date formatting, etc.) for use in your Laravel application.",
   "type": "library",
   "license": "MIT",
   "keywords": [
     "laravel",
-    "titles"
+    "writing-style",
+    "title-case"
   ],
   "authors": [
     {
@@ -25,12 +26,12 @@
   },
   "autoload": {
     "psr-4": {
-      "Hotmeteor\\Titles\\": "src"
+      "Hotmeteor\\WritingStyle\\": "src"
     }
   },
   "autoload-dev": {
     "psr-4": {
-      "Hotmeteor\\Titles\\Tests\\": "tests/"
+      "Hotmeteor\\WritingStyle\\Tests\\": "tests/"
     }
   },
   "scripts": {
@@ -39,10 +40,10 @@
   "extra": {
     "laravel": {
       "providers": [
-        "Hotmeteor\\Titles\\TitlesServiceProvider"
+        "Hotmeteor\\WritingStyle\\TitlesServiceProvider"
       ],
       "aliases": {
-        "Title": "Hotmeteor\\Titles\\Facade"
+        "Title": "Hotmeteor\\WritingStyle\\Facade"
       }
     }
   },

--- a/src/Facade.php
+++ b/src/Facade.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hotmeteor\Titles;
+namespace Hotmeteor\WritingStyle;
 
 use Illuminate\Support\Facades\Facade as LaravelFacade;
 

--- a/src/TitleFactory.php
+++ b/src/TitleFactory.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hotmeteor\Titles;
+namespace Hotmeteor\WritingStyle;
 
 class TitleFactory
 {

--- a/src/TitlesServiceProvider.php
+++ b/src/TitlesServiceProvider.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hotmeteor\Titles;
+namespace Hotmeteor\WritingStyle;
 
 
 use Illuminate\Support\ServiceProvider;


### PR DESCRIPTION
Fix https://github.com/hotmeteor/titles/issues/2

As per https://github.com/hotmeteor/issues/titles#4#issuecomment-1889636408

This would also require renaming the repository itself

Supersedes https://github.com/hotmeteor/titles/pull/6 since [hotmeteor/titles](https://github.com/hotmeteor) is discontinued